### PR TITLE
トースト通知の追加。

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "dependencies": {
         "@skyway-sdk/room": "^1.15.1",
         "uuidv4": "^6.2.13",
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-toast-notification": "^3.1.3",
+        "vue-toastification": "^2.0.0-rc.5",
+        "vue3-toastify": "^0.2.8"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.12",
@@ -2855,6 +2858,45 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-toast-notification": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vue-toast-notification/-/vue-toast-notification-3.1.3.tgz",
+      "integrity": "sha512-XNyWqwLIGBFfX5G9sK+clq3N3IPlhDjzNdbZaXkEElcotPlWs0wWZailk1vqhdtLYT/93Y4FHAVuzyatLmPZRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.15.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0"
+      }
+    },
+    "node_modules/vue-toastification": {
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz",
+      "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.2"
+      }
+    },
+    "node_modules/vue3-toastify": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/vue3-toastify/-/vue3-toastify-0.2.8.tgz",
+      "integrity": "sha512-8jDOqsJaBZEbGpCbhWDETJc11D1lZefvgFPq/IPdM+U7+qyXoVPDvK6uq/FIgyV7qV0NcNzvGBMEzjsLQqGROw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20",
+        "npm": ">=9.0.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "vue": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "dependencies": {
     "@skyway-sdk/room": "^1.15.1",
     "uuidv4": "^6.2.13",
-    "vue": "^3.5.18"
+    "vue": "^3.5.18",
+    "vue-toast-notification": "^3.1.3",
+    "vue-toastification": "^2.0.0-rc.5",
+    "vue3-toastify": "^0.2.8"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/src/components/StreamReceiver.vue
+++ b/src/components/StreamReceiver.vue
@@ -1,7 +1,10 @@
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue'; // onUnmountedを追加
+import { ref, onMounted, onUnmounted } from 'vue'; 
 import { SkyWayContext, SkyWayRoom, SkyWayStreamFactory, uuidV4 } from '@skyway-sdk/room';
 import GetToken from './SkywayToken.js';
+//トースト追加
+import { toast } from 'vue3-toastify';
+import "vue3-toastify/dist/index.css";
 
 // 環境変数 (vite)
 const appId = import.meta.env.VITE_SKYWAY_APP_ID;
@@ -26,7 +29,8 @@ const Leaving = ref(false);// 退出中フラグ（追加：leave 完了前の�
 // ミュート状態管理（新規追加）
 const IsAudioMuted = ref(false);
 const IsVideoMuted = ref(false);
-const IsScreenSharing = ref(false); // 画面共有状態管理（追加）
+// 画面共有状態管理（追加）
+const IsScreenSharing = ref(false); 
 const baseUrl = window.location.href.split('?')[0];
 // Publication を保持（publish の戻り値として得られるオブジェクト）
 const LocalVideoPublication = ref(null);
@@ -64,7 +68,7 @@ const getContext = async () => {
     });
     return context.ctx;
   } catch (e) {
-    ErrorMessage.value = 'Context 作成失敗: ' + e;
+    toast.error('Context 作成失敗: ' + e);
     console.error(e);
   }
 };
@@ -81,7 +85,7 @@ const createRoom = async () => {
     });
     RoomCreated.value = true;
   } catch (e) {
-    ErrorMessage.value = 'Room 作成失敗: ' + e;
+    toast.error('Room 作成失敗: ' + e);
     console.error(e);
   }
 };
@@ -238,14 +242,13 @@ const toggleVideoMute = async () => {
   if (!ok) console.warn('Video mute/unmute failed (no publication & no track)');
 };
 //画面共有
-const screenshare = async () => {
+const screenShare = async () => {
   if (!LocalMember.value) return;
   
   try {
     if (IsScreenSharing.value) {
       // 画面共有停止 - 元のカメラ映像に戻す
       await LocalMember.value.unpublish(LocalVideoPublication.value);
-      
       // カメラ映像を再作成してpublish
       const cameraStream = await SkyWayStreamFactory.createCameraVideoStream();
       LocalVideoStream.value = cameraStream;
@@ -282,12 +285,12 @@ const screenshare = async () => {
     }
   } catch (error) {
     console.error('画面共有エラー:', error);
-    ErrorMessage.value = '画面共有に失敗しました: ' + error.message;
+    toast.value = '画面共有に失敗しました: ' + error.message;
   }
 };
 
-// 映像拡大機能（追加）
-// enlargeVideo関数を以下のように修正
+// 映像拡大機能
+// enlargeVideo関数
 const enlargeVideo = (videoEl) => {
   if (EnlargedVideo.value) return;
   
@@ -354,7 +357,7 @@ const handleKeydown = (e) => {
 const joinRoom = async () => {
   if (Joining.value || Joined.value || Leaving.value) return; // Leaving 中は不可（追加）
   if (!RoomId.value) {
-    alert('No Room ID');
+    toast.error('ルームIDが設定されていません');
     return;
   }
   try {
@@ -436,7 +439,7 @@ try {
 
     Joined.value = true;
   } catch (e) {
-    ErrorMessage.value = 'Join 失敗: ' + e;
+    toast.error('ルーム参加に失敗しました: ' + e);
     console.error(e);
   } finally {
     Joining.value = false;
@@ -598,7 +601,7 @@ onUnmounted(() => {
         </button>
         <!--画面共有ボタン-->
         <button
-          @click="screenshare"
+          @click="screenShare"
           :class="[
             'inline-flex items-center px-4 py-2 rounded font-medium focus:outline-none focus:ring-2',
             IsScreenSharing


### PR DESCRIPTION
WHY

エラー文が出た時に今のUIデザインだとずっと残ってしまったりしてしまったり
不快な気分にさせるのでトーストの追加する

WHAT
npm install vue-toastification@next
で環境構築
import { toast } from 'vue3-toastify';
import 'vue3-toastify/dist/index.css';
この二つをインポート
各関数のエラーメッセージ（error.message);を toast.errorでトースト
を使う

camelケースは次に改善します。
